### PR TITLE
FoundryGet integration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
+[![](https://img.shields.io/badge/FoundryGet-compatible-success)](https://github.com/cswendrowski/foundryget)
+
 # FoundryVTT - Forien's Armoury
 **[Current version]**: v0.2.7  
 **[Compatibility]**: *FoundryVTT* 0.6.0+, *WFRP4e* 1.5.5+   
 **[Optional modules]**: *Babele* 1.19+ (required for translations)
 
 This module is a collection of custom trappings and features for Warhammer Fantasy Role-Play 4th edition game system for Foundry Virtual Table Top
+
+## Recommended: Install via [FoundryGet](https://github.com/cswendrowski/foundryget)
+
+FoundryGet will automatically install downstream dependencies such as Babele and manage version conflicts.
+
+```
+foundryget install https://raw.githubusercontent.com/Forien/foundryvtt-forien-armoury/master/module.json
+```
+
 
 #### Notable changes in v0.2.*
 * Extended Arrow Recovery system with more rules

--- a/README.md
+++ b/README.md
@@ -7,15 +7,6 @@
 
 This module is a collection of custom trappings and features for Warhammer Fantasy Role-Play 4th edition game system for Foundry Virtual Table Top
 
-## Recommended: Install via [FoundryGet](https://github.com/cswendrowski/foundryget)
-
-FoundryGet will automatically install downstream dependencies such as Babele and manage version conflicts.
-
-```
-foundryget install https://raw.githubusercontent.com/Forien/foundryvtt-forien-armoury/master/module.json
-```
-
-
 #### Notable changes in v0.2.*
 * Extended Arrow Recovery system with more rules
 * Added new qualities and flaws to use with projectiles:
@@ -37,9 +28,21 @@ foundryget install https://raw.githubusercontent.com/Forien/foundryvtt-forien-ar
 
 ## Installation
 
+### Recommended: Install via [FoundryGet](https://github.com/cswendrowski/foundryget)
+
+FoundryGet will automatically install downstream dependencies such as Babele and manage version conflicts.
+
+```
+foundryget install https://raw.githubusercontent.com/Forien/foundryvtt-forien-armoury/master/module.json
+```
+
+Once installed, while in World using WFRP4e game system, enable Forien's Armoury module
+
+### Manual
+
 1. Install [WFRP4e Game System](https://github.com/CatoThe1stElder/WFRP-4th-Edition-FoundryVTT).
 2. Install Forien's Armoury using manifest URL: https://raw.githubusercontent.com/Forien/foundryvtt-forien-armoury/master/module.json
-3. While in World using WFRP4e game system, enable Forien's Armoury module.
+3. While in World using WFRP4e game system, enable Forien's Armoury module
 
 
 ## Contents

--- a/module.json
+++ b/module.json
@@ -15,6 +15,11 @@
   ],
   "dependencies": [
     {
+        "name": "wfrp4e",
+        "manifest": "https://raw.githubusercontent.com/CatoThe1stElder/WFRP-4th-Edition-FoundryVTT/stable/system.json",
+        "version": "1.5.5"
+    },
+    {
         "name": "babele",
         "manifest": "https://gitlab.com/riccisi/foundryvtt-babele/raw/master/module/module.json",
         "version": "1.19.0"

--- a/module.json
+++ b/module.json
@@ -13,6 +13,13 @@
       "url": "https://github.com/DasSauerkraut"
     }
   ],
+  "dependencies": [
+    {
+        "name": "babele",
+        "manifest": "https://gitlab.com/riccisi/foundryvtt-babele/raw/master/module/module.json",
+        "version": "1.19.0"
+    }
+  ],
   "system": "wfrp4e",
   "version": "0.2.7",
   "minimumCoreVersion": "0.6.0",


### PR DESCRIPTION
This will allow users to install Forien-Armoury without manually installing Babele nor Settings-Extender

Related:
https://gitlab.com/riccisi/foundryvtt-babele/-/merge_requests/3
https://gitlab.com/foundry-azzurite/settings-extender/-/merge_requests/2


Feel free to chat with me about this MR in Discord: Toon324#9701